### PR TITLE
Modified to use replaceState instead of pushState

### DIFF
--- a/MVCGrid/Scripts/MVCGrid.js
+++ b/MVCGrid/Scripts/MVCGrid.js
@@ -378,8 +378,8 @@ var MVCGrid = new function () {
     // private
     var setURLAndReload = function (mvcGridName, newUrl) {
 
-        if (history.pushState) {
-            window.history.pushState({ path: newUrl }, '', newUrl);
+        if (history.replaceState) {
+            window.history.replaceState({ path: newUrl }, '', newUrl);
             MVCGrid.reloadGrid(mvcGridName);
         }
         else {


### PR DESCRIPTION
It's great to have the history, but most of the time I want to come back from a page and show the most recent sort/filter that I had on the grid.  I don't want to sort a grid and then click the back button, only to go back to the previous sort.
